### PR TITLE
Add PDF processing script and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # pdf
-pdf
+
+A simple utility to extract tables from PDF files and export them as CSV.
+
+## Example
+
+```
+python process_pdf.py input.pdf output.csv "Column1,Column2,Column3"
+```
+
+This command extracts tables from `input.pdf` and writes them to `output.csv`. If no rows are found, the script creates an empty CSV with the specified header row.

--- a/process_pdf.py
+++ b/process_pdf.py
@@ -1,0 +1,40 @@
+import csv
+import sys
+
+import pdfplumber
+
+
+def process_pdf(pdf_path, csv_path, headers=None):
+    out_rows = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            table = page.extract_table()
+            if table:
+                out_rows.extend(table)
+
+    if not out_rows:
+        if headers:
+            with open(csv_path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(headers)
+        else:
+            print(f"Warning: no rows found in {pdf_path}; no CSV created")
+        return
+
+    if headers is None:
+        headers, *out_rows = out_rows
+
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        writer.writerows(out_rows)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: process_pdf.py <input.pdf> <output.csv> [comma-separated headers]")
+        sys.exit(1)
+    pdf_path = sys.argv[1]
+    csv_path = sys.argv[2]
+    headers = sys.argv[3].split(',') if len(sys.argv) > 3 else None
+    process_pdf(pdf_path, csv_path, headers)


### PR DESCRIPTION
## Summary
- add a small utility `process_pdf.py` to extract tables from PDF files
- ensure an empty CSV with headers is produced when no rows are extracted
- document how to run the script in `README.md`

## Testing
- `python -m py_compile process_pdf.py`
- `python process_pdf.py` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_b_685bf0a3b8a88333bc973035a3755ee5