### PR TITLE
Add official sources collector and integrate into web app

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Utility modules for the derussification helper web application."""
+

--- a/scripts/collect_official_sources.py
+++ b/scripts/collect_official_sources.py
@@ -1,0 +1,428 @@
+"""Tools for collecting official derussification-related sources.
+
+This module provides three main building blocks:
+
+``ADMINISTRATIVE_HIERARCHY``
+    A nested dictionary that documents the hierarchy of administrative
+    units (обласні військові адміністрації, районні/міські/селищні ради
+    та територіальні громади) together with links to their official
+    websites.  The structure is intentionally compact – it contains a
+    representative subset that can be extended in-place without touching
+    the rest of the code.
+
+``DecisionRegistry``
+    A small data container that keeps the links to decisions on
+    дерусифікація, декомунізація, топонімічні зміни тощо.  The registry is
+    designed to be easily extendable: new categories can be introduced on
+    the fly, and the collected data can be exported either as JSON or CSV.
+
+``OfficialSourceCollector``
+    A helper that iterates over the configured official websites,
+    attempts to locate hyperlinks that match category-specific keywords
+    and stores the results inside ``DecisionRegistry``.  The collector is
+    intentionally conservative – in offline environments or when a site
+    does not respond it simply records the error instead of failing the
+    whole run.
+
+The module keeps the dependencies limited to the Python standard library
+so that it can run both as a standalone script and inside the existing
+Flask web application without any additional setup.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.error import URLError
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Administrative hierarchy and official sources.
+
+
+ADMINISTRATIVE_HIERARCHY: Dict[str, object] = {
+    "name": "Україна",
+    "type": "країна",
+    "children": [
+        {
+            "name": "Київська область",
+            "type": "обласна військова адміністрація",
+            "website": "https://kyivoda.gov.ua/",
+            "children": [
+                {
+                    "name": "Білоцерківський район",
+                    "type": "районна державна адміністрація",
+                    "website": "https://bcrda.gov.ua/",
+                    "children": [
+                        {
+                            "name": "Біла Церква",
+                            "type": "міська рада",
+                            "website": "https://bc-rada.gov.ua/",
+                            "communities": [
+                                {
+                                    "name": "Білоцерківська міська територіальна громада",
+                                    "website": "https://bc-rada.gov.ua/",
+                                }
+                            ],
+                        },
+                        {
+                            "name": "Тараща",
+                            "type": "міська рада",
+                            "website": "https://tarashcha-rada.gov.ua/",
+                            "communities": [
+                                {
+                                    "name": "Таращанська міська територіальна громада",
+                                    "website": "https://tarashcha-rada.gov.ua/",
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "name": "Бориспільський район",
+                    "type": "районна державна адміністрація",
+                    "website": "https://borsrda.gov.ua/",
+                    "children": [
+                        {
+                            "name": "Бориспіль",
+                            "type": "міська рада",
+                            "website": "https://borispol-rada.gov.ua/",
+                            "communities": [
+                                {
+                                    "name": "Бориспільська міська територіальна громада",
+                                    "website": "https://borispol-rada.gov.ua/",
+                                }
+                            ],
+                        },
+                        {
+                            "name": "Переяслав",
+                            "type": "міська рада",
+                            "website": "https://pereyaslavrada.gov.ua/",
+                            "communities": [
+                                {
+                                    "name": "Переяславська міська територіальна громада",
+                                    "website": "https://pereyaslavrada.gov.ua/",
+                                }
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "Львівська область",
+            "type": "обласна військова адміністрація",
+            "website": "https://loda.gov.ua/",
+            "children": [
+                {
+                    "name": "Львівський район",
+                    "type": "районна державна адміністрація",
+                    "website": "https://lvivska-rda.gov.ua/",
+                    "children": [
+                        {
+                            "name": "Львів",
+                            "type": "міська рада",
+                            "website": "https://city-adm.lviv.ua/",
+                            "communities": [
+                                {
+                                    "name": "Львівська міська територіальна громада",
+                                    "website": "https://city-adm.lviv.ua/",
+                                },
+                                {
+                                    "name": "Рудківська міська територіальна громада",
+                                    "website": "https://rudkivska-gromada.gov.ua/",
+                                },
+                            ],
+                        },
+                        {
+                            "name": "Дрогобич",
+                            "type": "міська рада",
+                            "website": "https://drohobych-rada.gov.ua/",
+                            "communities": [
+                                {
+                                    "name": "Дрогобицька міська територіальна громада",
+                                    "website": "https://drohobych-rada.gov.ua/",
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ],
+        },
+    ],
+}
+
+
+# Flattened view of official websites that will be iterated by the collector.
+OFFICIAL_SOURCES: List[Dict[str, str]] = [
+    {
+        "name": "Київська ОВА",
+        "admin_unit": "Київська область",
+        "url": "https://kyivoda.gov.ua/",
+    },
+    {
+        "name": "Київська обласна рада",
+        "admin_unit": "Київська область",
+        "url": "https://kor.gov.ua/",
+    },
+    {
+        "name": "Біла Церква – міська рада",
+        "admin_unit": "Біла Церква",
+        "url": "https://bc-rada.gov.ua/",
+    },
+    {
+        "name": "Бориспіль – міська рада",
+        "admin_unit": "Бориспіль",
+        "url": "https://borispol-rada.gov.ua/",
+    },
+    {
+        "name": "Львівська ОВА",
+        "admin_unit": "Львівська область",
+        "url": "https://loda.gov.ua/",
+    },
+    {
+        "name": "Львівська міська рада",
+        "admin_unit": "Львів",
+        "url": "https://city-adm.lviv.ua/",
+    },
+]
+
+
+DEFAULT_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "derussification": (
+        "дерусифіка",
+        "derussification",
+        "деколонізац",
+    ),
+    "decommunisation": (
+        "декомунізац",
+        "decommunis",
+    ),
+    "toponymy": (
+        "топонім",
+        "перейменув",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Data containers.
+
+
+@dataclass
+class DecisionLink:
+    """A single reference to an official decision."""
+
+    category: str
+    admin_unit: str
+    title: str
+    url: str
+    source: str
+    fetched_at: float = field(default_factory=time.time)
+    note: Optional[str] = None
+
+
+class DecisionRegistry:
+    """Container for collected decision links."""
+
+    def __init__(self, categories: Optional[Iterable[str]] = None) -> None:
+        self._categories: Dict[str, List[DecisionLink]] = {
+            category: [] for category in (categories or DEFAULT_KEYWORDS.keys())
+        }
+        self._errors: List[str] = []
+
+    # -- internal helpers -------------------------------------------------
+
+    def _ensure_category(self, category: str) -> None:
+        if category not in self._categories:
+            self._categories[category] = []
+
+    # -- public API -------------------------------------------------------
+
+    def add_link(
+        self,
+        category: str,
+        admin_unit: str,
+        title: str,
+        url: str,
+        source: str,
+        note: Optional[str] = None,
+    ) -> None:
+        self._ensure_category(category)
+        self._categories[category].append(
+            DecisionLink(
+                category=category,
+                admin_unit=admin_unit,
+                title=title.strip(),
+                url=url,
+                source=source,
+                note=note,
+            )
+        )
+
+    def add_error(self, message: str) -> None:
+        LOGGER.warning("Collector error: %s", message)
+        self._errors.append(message)
+
+    @property
+    def errors(self) -> List[str]:
+        return self._errors
+
+    def to_dict(self) -> Dict[str, List[Dict[str, object]]]:
+        return {
+            category: [link.__dict__ for link in links]
+            for category, links in self._categories.items()
+        }
+
+    def to_csv(self, stream) -> None:
+        writer = csv.DictWriter(
+            stream,
+            fieldnames=[
+                "category",
+                "admin_unit",
+                "title",
+                "url",
+                "source",
+                "fetched_at",
+                "note",
+            ],
+        )
+        writer.writeheader()
+        for links in self._categories.values():
+            for link in links:
+                writer.writerow(link.__dict__)
+
+    def to_json(self, stream, ensure_ascii: bool = False, indent: int = 2) -> None:
+        json.dump(self.to_dict(), stream, ensure_ascii=ensure_ascii, indent=indent)
+
+
+# ---------------------------------------------------------------------------
+# Collector implementation.
+
+
+class _AnchorExtractor(HTMLParser):
+    """HTML parser that extracts anchors."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: List[Tuple[str, str]] = []
+        self._current_href: Optional[str] = None
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]):
+        if tag.lower() != "a":
+            return
+        href = None
+        for key, value in attrs:
+            if key.lower() == "href":
+                href = value
+                break
+        self._current_href = href
+
+    def handle_endtag(self, tag: str):
+        if tag.lower() == "a":
+            self._current_href = None
+
+    def handle_data(self, data: str):
+        if self._current_href:
+            text = data.strip()
+            if text:
+                self.links.append((text, self._current_href))
+
+
+class OfficialSourceCollector:
+    """Iterate over official sources and extract candidate links."""
+
+    def __init__(
+        self,
+        sources: Iterable[Dict[str, str]],
+        keywords: Optional[Dict[str, Tuple[str, ...]]] = None,
+    ) -> None:
+        self.sources = list(sources)
+        self.keywords = keywords or DEFAULT_KEYWORDS
+
+    # -- network ----------------------------------------------------------
+
+    def fetch(self, url: str) -> str:
+        LOGGER.info("Fetching %s", url)
+        with urlopen(url, timeout=15) as response:  # nosec - trusted domains
+            charset = response.headers.get_content_charset() or "utf-8"
+            return response.read().decode(charset, errors="replace")
+
+    # -- parsing ----------------------------------------------------------
+
+    def extract_anchors(self, html: str) -> List[Tuple[str, str]]:
+        parser = _AnchorExtractor()
+        parser.feed(html)
+        return parser.links
+
+    def match_category(self, text: str) -> Optional[str]:
+        lowered = text.lower()
+        for category, needles in self.keywords.items():
+            if any(needle in lowered for needle in needles):
+                return category
+        return None
+
+    # -- public API -------------------------------------------------------
+
+    def collect(self, registry: DecisionRegistry) -> DecisionRegistry:
+        for source in self.sources:
+            url = source.get("url")
+            if not url:
+                registry.add_error(f"Source without URL: {source}")
+                continue
+            name = source.get("name", url)
+            admin_unit = source.get("admin_unit", name)
+            try:
+                html = self.fetch(url)
+            except URLError as exc:  # pragma: no cover - depends on network
+                registry.add_error(f"Не вдалося отримати {url}: {exc}")
+                continue
+            except Exception as exc:  # pragma: no cover - defensive
+                registry.add_error(f"Помилка під час обробки {url}: {exc}")
+                continue
+
+            for text, href in self.extract_anchors(html):
+                category = self.match_category(text)
+                if not category:
+                    continue
+                absolute_url = urljoin(url, href)
+                registry.add_link(
+                    category=category,
+                    admin_unit=admin_unit,
+                    title=text,
+                    url=absolute_url,
+                    source=name,
+                )
+        return registry
+
+
+def collect_official_decisions() -> DecisionRegistry:
+    """Convenience helper for one-off collection runs."""
+
+    registry = DecisionRegistry()
+    collector = OfficialSourceCollector(OFFICIAL_SOURCES)
+    collector.collect(registry)
+    return registry
+
+
+__all__ = [
+    "ADMINISTRATIVE_HIERARCHY",
+    "OFFICIAL_SOURCES",
+    "DEFAULT_KEYWORDS",
+    "DecisionLink",
+    "DecisionRegistry",
+    "OfficialSourceCollector",
+    "collect_official_decisions",
+]
+

--- a/scripts/webapp.py
+++ b/scripts/webapp.py
@@ -1,9 +1,24 @@
 from flask import Flask, request, render_template, send_file, redirect, url_for
 import csv
 import io
+from pathlib import Path
+import sys
 from typing import List, Dict
 
-app = Flask(__name__)
+BASE_DIR = Path(__file__).resolve().parent
+ROOT_DIR = BASE_DIR.parent
+
+if __package__ in (None, ""):
+    sys.path.append(str(ROOT_DIR))
+
+app = Flask(__name__, template_folder=str(ROOT_DIR / "templates"))
+
+from scripts.collect_official_sources import (  # noqa: E402,E401
+    ADMINISTRATIVE_HIERARCHY,
+    OFFICIAL_SOURCES,
+    DecisionRegistry,
+    OfficialSourceCollector,
+)
 
 
 def normalize(text: str) -> str:
@@ -74,6 +89,43 @@ def batch():
         processed = process_file(rows, normalise=normalise)
         return render_template("batch_result.html", rows=processed)
     return render_template("batch.html")
+
+
+@app.route("/official-sources")
+def official_sources():
+    download = request.args.get("download")
+    collector = OfficialSourceCollector(OFFICIAL_SOURCES)
+    registry = collector.collect(DecisionRegistry())
+
+    if download == "csv":
+        output = io.StringIO()
+        registry.to_csv(output)
+        output.seek(0)
+        return send_file(
+            io.BytesIO(output.getvalue().encode("utf-8")),
+            mimetype="text/csv",
+            as_attachment=True,
+            download_name="official_decisions.csv",
+        )
+
+    if download == "json":
+        output = io.StringIO()
+        registry.to_json(output, ensure_ascii=False)
+        output.seek(0)
+        return send_file(
+            io.BytesIO(output.getvalue().encode("utf-8")),
+            mimetype="application/json",
+            as_attachment=True,
+            download_name="official_decisions.json",
+        )
+
+    return render_template(
+        "official_sources.html",
+        hierarchy=ADMINISTRATIVE_HIERARCHY,
+        registry=registry.to_dict(),
+        errors=registry.errors,
+        sources=OFFICIAL_SOURCES,
+    )
 
 
 @app.route("/normalize", methods=["GET", "POST"])

--- a/templates/official_sources.html
+++ b/templates/official_sources.html
@@ -1,0 +1,87 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Офіційні джерела</h2>
+<p>
+    Цей розділ збирає посилання на рішення про дерусифікацію,
+    декомунізацію та інші топонімічні зміни на основі відкритих даних
+    з офіційних сайтів органів влади. Завантажити результати можна у
+    форматі <a href="{{ url_for('official_sources', download='csv') }}">CSV</a>
+    або <a href="{{ url_for('official_sources', download='json') }}">JSON</a>.
+</p>
+
+{% if errors %}
+<div style="border:1px solid #cc0000; padding: 0.5rem; background: #ffe6e6;">
+    <strong>Попередження:</strong>
+    <ul>
+        {% for error in errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+<h3>Знайдені рішення</h3>
+{% if registry %}
+    {% for category, items in registry.items() %}
+        <h4>{{ category|capitalize }} ({{ items|length }})</h4>
+        {% if items %}
+        <ul>
+            {% for item in items %}
+            <li>
+                <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>
+                &mdash; {{ item.admin_unit }} ({{ item.source }})
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>Поки що нічого не знайдено.</p>
+        {% endif %}
+    {% endfor %}
+{% else %}
+<p>Поки що нічого не знайдено.</p>
+{% endif %}
+
+<h3>Список джерел</h3>
+<ul>
+    {% for source in sources %}
+    <li><a href="{{ source.url }}" target="_blank" rel="noopener">{{ source.name }}</a> &mdash; {{ source.admin_unit }}</li>
+    {% endfor %}
+</ul>
+
+<h3>Адміністративна ієрархія</h3>
+{% macro render_unit(unit) %}
+    <li>
+        <strong>{{ unit.name }}</strong>
+        {% if unit.type %}
+            &mdash; {{ unit.type }}
+        {% endif %}
+        {% if unit.website %}
+            (<a href="{{ unit.website }}" target="_blank" rel="noopener">{{ unit.website }}</a>)
+        {% endif %}
+        {% if unit.communities %}
+        <ul>
+            {% for community in unit.communities %}
+            <li>
+                {{ community.name }}
+                {% if community.website %}
+                    (<a href="{{ community.website }}" target="_blank" rel="noopener">{{ community.website }}</a>)
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% if unit.children %}
+        <ul>
+            {% for child in unit.children %}
+                {{ render_unit(child) }}
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+<ul>
+    {{ render_unit(hierarchy) }}
+</ul>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable collector module with administrative hierarchy metadata and export helpers
- integrate official decision collection into the Flask app with download options
- add a template that visualises the hierarchy, sources and collected links

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_b_68dacef8db64833382169282fd7d0e3c